### PR TITLE
Add option to executing composer in separate directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Loading the plugin via JavaScript:
 grunt.loadNpmTasks('grunt-composer');
 ```
 
+### Options
+
+#### options.cwd
+Type: `String`
+Default value: `.`
+
+The directory in which to execute the composer command.
+
 
 ## Running Composer Commands
 

--- a/tasks/composer.coffee
+++ b/tasks/composer.coffee
@@ -7,9 +7,9 @@ composer
 module.exports = (grunt) ->
   spawn = require('child_process').spawn
 
-  execCmd = (cmd, args, cb) ->
+  execCmd = (cmd, args, cb, spawnOpts) ->
 
-    exec = spawn cmd, args
+    exec = spawn cmd, args, spawnOpts
     exec.stdout.on 'data', grunt.log.write
     exec.stderr.on 'data', grunt.log.error
     exec.on 'close', (code) ->
@@ -20,7 +20,12 @@ module.exports = (grunt) ->
 
   desc = 'Wrapper for Composer commands'
   grunt.registerTask 'composer', desc, (cmd, args...) ->
+    options = this.options()
+    spawnOpts = {}
+    if options.cwd
+      spawnOpts.cwd = options.cwd
+
     done = this.async()
     cmdArgs = ('--' + arg for arg in args)
     cmdArgs.unshift cmd
-    execCmd 'composer', cmdArgs, done
+    execCmd 'composer', cmdArgs, done, spawnOpts


### PR DESCRIPTION
I'm using this as part of a packaging task, so I've added an option that allows changing the directory composer runs in. That way I can run composer in a build directory.
