### PR TITLE
reset cwd on finish

### DIFF
--- a/tasks/composer.coffee
+++ b/tasks/composer.coffee
@@ -29,8 +29,13 @@ module.exports.handleTask = (self, command, flags) ->
   .withCommand(command)
   .build()
 
+  cur_cwd = process.cwd()
   cwd = self.options().cwd
+
   if cwd
     cd(cwd)
 
   exec(commandToRun).code == 0
+
+  if cwd
+    cd(cur_cwd)


### PR DESCRIPTION
Return to the original cwd after composer.

This is necessary if you have subsequent jobs that depend on the cwd.
