### PR TITLE
Ensure failing tests make "grunt test" return a non-healthy exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "A grunt wrapper for composer",
   "scripts": {
-    "test": "grunt test; grunt composer:self:update"
+    "test": "grunt test && grunt composer:self:update"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should ensure Travis builds are representative, and highlight an existing failing test in the build.
